### PR TITLE
Changes

### DIFF
--- a/src/main/java/optic_fusion1/mcantimalware/DirectoryWatcherService.java
+++ b/src/main/java/optic_fusion1/mcantimalware/DirectoryWatcherService.java
@@ -83,7 +83,7 @@ public class DirectoryWatcherService implements Runnable {
             return;
         }
         boolean alreadyAdded = filesToReload.add(filename) == false;
-        Main.getLogger().info("Queuing file for processing: "
+        main.getLogger().info("Queuing file for processing: "
                 + filename + (alreadyAdded ? "(already queued)" : ""));
         if (processDelayTimer != null) {
             processDelayTimer.cancel();
@@ -124,7 +124,7 @@ public class DirectoryWatcherService implements Runnable {
                     continue;
                 }
                 if (!file.getName().contains("MCAntiMalware") && !file.getName().contains("malplugins.zip")) {
-                    Main.getLogger().info("Detected new file " + file.getName() + " checking if it's malicious");
+                    main.getLogger().info("Detected new file " + file.getName() + " checking if it's malicious");
                     main.getCheckManager().process(file.getName(), file);
                 }
             }

--- a/src/main/java/optic_fusion1/mcantimalware/Main.java
+++ b/src/main/java/optic_fusion1/mcantimalware/Main.java
@@ -40,6 +40,7 @@ public class Main implements Runnable {
     private ConsoleReader reader;
 
     private void init() {
+        logger.getLogger().setLevel(Level.ALL);
         File file = new File("AntiMalware");
         if (!file.exists()) {
             file.mkdirs();
@@ -102,7 +103,7 @@ public class Main implements Runnable {
             if (options.has("zipMalPlugins")) {
                 zipMaliciousPlugins = (Boolean) options.valueOf("zipMalPlugins");
             }
-            if(options.has("debug")){
+            if (options.has("debug")) {
                 showDebugMessages = (Boolean) options.valueOf("debug");
             }
         }
@@ -111,7 +112,10 @@ public class Main implements Runnable {
     @Override
     public void run() {
         init();
-        System.out.println("Should zip malicious plugins: " + zipMaliciousPlugins);
+        if (showDebugMessages) {
+            logger.debug("Should zip malicious plugins: " + zipMaliciousPlugins);
+            logger.debug("Should print debug messages: " + showDebugMessages);
+        }
         watcher.start();
         watcher.firstRun();
     }
@@ -165,10 +169,10 @@ public class Main implements Runnable {
         maliciousPluginsFound = foundMaliciousPlugins;
     }
 
-    public boolean shouldLogDebugMessages(){
+    public boolean shouldLogDebugMessages() {
         return showDebugMessages;
     }
-    
+
     public boolean foundMaliciousPlugins() {
         return maliciousPluginsFound;
     }
@@ -177,7 +181,7 @@ public class Main implements Runnable {
         return reader;
     }
 
-    public static CustomLogger getLogger() {
+    public CustomLogger getLogger() {
         return logger;
     }
 

--- a/src/main/java/optic_fusion1/mcantimalware/check/Check.java
+++ b/src/main/java/optic_fusion1/mcantimalware/check/Check.java
@@ -21,6 +21,10 @@ public abstract class Check {
         this.main = main;
         this.type = type;
     }
+    
+    public Main getMain(){
+        return main;
+    }
 
     public void setFileName(String fileName) {
         this.fileName = fileName;

--- a/src/main/java/optic_fusion1/mcantimalware/check/CheckManager.java
+++ b/src/main/java/optic_fusion1/mcantimalware/check/CheckManager.java
@@ -14,10 +14,11 @@ public class CheckManager {
 
     private List<Check> checks = new ArrayList<>();
     private Main main;
-    private CustomLogger logger = Main.getLogger();
+    private CustomLogger logger;
 
     public CheckManager(Main main) {
         this.main = main;
+        this.logger = main.getLogger();
     }
 
     public List<Check> getChecks() {

--- a/src/main/java/optic_fusion1/mcantimalware/check/checks/DirectLeaks.java
+++ b/src/main/java/optic_fusion1/mcantimalware/check/checks/DirectLeaks.java
@@ -83,7 +83,7 @@ public class DirectLeaks extends Check {
         return false;
     }
 
-    public static boolean containsBlacklistedWord(String string) {
+    public boolean containsBlacklistedWord(String string) {
         String[] blacklistedWords = new String[]{
             "#directleaks", "Please contact DirectLeaks. 0x2", "http://api.directleaks.net/api/directleaks",
             "[DirectLeaks] Error Code: 0x1", "Anti-Releak", "DirectLeaks", "vmi209890.contaboserver.net",

--- a/src/main/java/optic_fusion1/mcantimalware/logging/ConsoleLogManager.java
+++ b/src/main/java/optic_fusion1/mcantimalware/logging/ConsoleLogManager.java
@@ -10,9 +10,11 @@ import optic_fusion1.mcantimalware.Main;
 
 public class ConsoleLogManager {
 
-    private static Logger logger = Logger.getLogger("AntiMalware");
-    private static Logger global = Logger.getLogger("");
+    private static CustomLogger logger = CustomLogger.getLogger("AntiMalware");
+    private static CustomLogger global = CustomLogger.getLogger("");
 
+//    private static Logger logger = Logger.getLogger("AntiMalware");
+//    private static Logger global = Logger.getLogger("");
     public static void init(Main main) {
         final ConsoleLogFormatter consolelogformatter = new ConsoleLogFormatter();
         ConsoleLogManager.logger.setUseParentHandlers(false);
@@ -21,15 +23,17 @@ public class ConsoleLogManager {
             ConsoleLogManager.global.removeHandler(handler);
         }
         consolehandler.setFormatter(new ShortConsoleLogFormatter(main));
+        consolehandler.setLevel(Level.ALL);
         ConsoleLogManager.global.addHandler(consolehandler);
         ConsoleLogManager.logger.addHandler(consolehandler);
         try {
             File file = new File("AntiMalware", "log.log");
-            if(!file.exists()){
+            if (!file.exists()) {
                 file.mkdirs();
                 file.createNewFile();
             }
             final FileHandler filehandler = new FileHandler(file.toString(), true);
+            filehandler.setLevel(Level.ALL);
             filehandler.setFormatter(consolelogformatter);
             ConsoleLogManager.logger.addHandler(filehandler);
             ConsoleLogManager.global.addHandler(filehandler);

--- a/src/main/java/optic_fusion1/mcantimalware/logging/CustomLogger.java
+++ b/src/main/java/optic_fusion1/mcantimalware/logging/CustomLogger.java
@@ -1,13 +1,23 @@
 package optic_fusion1.mcantimalware.logging;
 
+import java.util.ResourceBundle;
+import java.util.function.Supplier;
+import java.util.logging.Filter;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 
 public class CustomLogger {
 
     private final Logger logger;
 
-    private CustomLogger(String clazzName) {
-        logger = Logger.getLogger(clazzName);
+    private CustomLogger(String loggerName) {
+        logger = Logger.getLogger(loggerName);
+    }
+
+    public static CustomLogger getLogger(String loggerName) {
+        return new CustomLogger(loggerName);
     }
 
     public static CustomLogger getLogger(Class<?> clazz) {
@@ -18,34 +28,34 @@ public class CustomLogger {
         return logger;
     }
 
-    public void finest(String msg){
+    public void finest(String msg) {
         logger.finest(msg);
     }
-    
-    public void finer(String msg){
+
+    public void finer(String msg) {
         logger.finer(msg);
     }
-    
-    public void fine(String msg){
+
+    public void fine(String msg) {
         logger.fine(msg);
     }
-    
-    public void config(String msg){
+
+    public void config(String msg) {
         logger.config(msg);
     }
-    
-    public void info(String msg){
+
+    public void info(String msg) {
         logger.info(msg);
     }
-    
-    public void warning(String msg){
+
+    public void warning(String msg) {
         logger.warning(msg);
     }
-    
-    public void severe(String msg){
+
+    public void severe(String msg) {
         logger.severe(msg);
     }
-    
+
     public void emergency(String msg) {
         logger.log(CustomLevel.EMERGENCY, msg);
     }
@@ -65,4 +75,197 @@ public class CustomLogger {
     public void debug(String msg) {
         logger.log(CustomLevel.DEBUG, msg);
     }
+
+    public void setParent(Logger parent) {
+        logger.setParent(parent);
+    }
+
+    public Logger getParent() {
+        return logger.getParent();
+    }
+
+    public void setResourceBundle(ResourceBundle bundle) {
+        logger.setResourceBundle(bundle);
+    }
+
+    public boolean getUseParentHandlers() {
+        return logger.getUseParentHandlers();
+    }
+
+    public void setUseParentHandlers(boolean useParentHandlers) {
+        logger.setUseParentHandlers(useParentHandlers);
+    }
+
+    public Handler[] getHandlers() {
+        return logger.getHandlers();
+    }
+
+    public void removeHandler(Handler handler) throws SecurityException {
+        logger.removeHandler(handler);
+    }
+
+    public void addHandler(Handler handler) throws SecurityException {
+        logger.addHandler(handler);
+    }
+
+    public String getName() {
+        return logger.getName();
+    }
+
+    public boolean isLoggable(Level level) {
+        return logger.isLoggable(level);
+    }
+
+    public Level getLevel() {
+        return logger.getLevel();
+    }
+
+    public void setLevel(Level newLevel) throws SecurityException {
+        logger.setLevel(newLevel);
+    }
+
+    public void finest(Supplier<String> msgSupplier) {
+        logger.finest(msgSupplier);
+    }
+
+    public void finer(Supplier<String> msgSupplier) {
+        logger.finer(msgSupplier);
+    }
+
+    public void fine(Supplier<String> msgSupplier) {
+        logger.fine(msgSupplier);
+    }
+
+    public void config(Supplier<String> msgSupplier) {
+        logger.config(msgSupplier);
+    }
+
+    public void info(Supplier<String> msgSupplier) {
+        logger.info(msgSupplier);
+    }
+
+    public void warning(Supplier<String> msgSupplier) {
+        logger.warning(msgSupplier);
+    }
+
+    public void severe(Supplier<String> msgSupplier) {
+        logger.severe(msgSupplier);
+    }
+
+    public void throwing(String sourceClass, String sourceMethod, Throwable thrown) {
+        logger.throwing(sourceClass, sourceMethod, thrown);
+    }
+
+    public void exiting(String sourceClass, String sourceMethod, Object result) {
+        logger.exiting(sourceClass, sourceMethod, result);
+    }
+
+    public void exiting(String sourceClass, String sourceMethod) {
+        logger.exiting(sourceClass, sourceMethod);
+   }
+
+    public void entering(String sourceClass, String sourceMethod, Object[] params) {
+        logger.entering(sourceClass, sourceMethod, params);
+    }
+
+    public void entering(String sourceClass, String sourceMethod, Object param1) {
+        logger.entering(sourceClass, sourceMethod, param1);
+    }
+
+    public void entering(String sourceClass, String sourceMethod) {
+        logger.entering(sourceClass, sourceMethod);
+    }
+
+    public void logrb(Level level, String sourceClass, String sourceMethod, ResourceBundle bundle, String msg, Throwable thrown) {
+        logger.logrb(level, sourceClass, sourceMethod, bundle, msg, thrown);
+    }
+
+    public void logrb(Level level, String sourceClass, String sourceMethod, String bundleName, String msg, Throwable thrown) {
+        logger.logrb(level, sourceClass, sourceMethod, bundleName, msg, thrown);
+    }
+
+    public void logrb(Level level, String sourceClass, String sourceMethod, ResourceBundle bundle, String msg, Object... params) {
+        logger.logrb(level, sourceClass, sourceMethod, bundle, msg, params);
+    }
+
+    public void logrb(Level level, String sourceClass, String sourceMethod, String bundleName, String msg, Object[] params) {
+        logger.logrb(level, sourceClass, sourceMethod, bundleName, msg, params);
+    }
+
+    public void logrb(Level level, String sourceClass, String sourceMethod, String bundleName, String msg, Object param1) {
+        logger.logrb(level, sourceClass, sourceMethod, bundleName, msg, param1);
+    }
+
+    public void logrb(Level level, String sourceClass, String sourceMethod, String bundleName, String msg) {
+        logger.logrb(level, sourceClass, sourceMethod, bundleName, msg);
+    }
+
+    public void logp(Level level, String sourceClass, String sourceMethod, Throwable thrown, Supplier<String> msgSupplier) {
+        logger.logp(level, sourceClass, sourceMethod, thrown, msgSupplier);
+    }
+
+    public void logp(Level level, String sourceClass, String sourceMethod, String msg, Throwable thrown) {
+        logger.logp(level, sourceClass, sourceMethod, msg, thrown);
+    }
+
+    public void logp(Level level, String sourceClass, String sourceMethod, String msg, Object[] params) {
+        logger.logp(level, sourceClass, sourceMethod, msg, params);
+    }
+
+    public void logp(Level level, String sourceClass, String sourceMethod, String msg, Object param1) {
+        logger.logp(level, sourceClass, sourceMethod, msg, param1);
+    }
+
+    public void logp(Level level, String sourceClass, String sourceMethod, Supplier<String> msgSupplier) {
+        logger.logp(level, sourceClass, sourceMethod, msgSupplier);
+    }
+
+    public void logp(Level level, String sourceClass, String sourceMethod, String msg) {
+        logger.logp(level, sourceClass, sourceMethod, msg);
+    }
+
+    public void log(Level level, Throwable thrown, Supplier<String> msgSupplier) {
+        logger.log(level, thrown, msgSupplier);
+    }
+
+    public void log(Level level, String msg, Throwable thrown) {
+        logger.log(level, msg, thrown);
+    }
+
+    public void log(Level level, String msg, Object[] params) {
+        logger.log(level, msg, params);
+    }
+
+    public void log(Level level, String msg, Object param1) {
+        logger.log(level, msg, param1);
+    }
+
+    public void log(Level level, Supplier<String> msgSupplier) {
+        logger.log(level, msgSupplier);
+    }
+
+    public void log(Level level, String msg) {
+        logger.log(level, msg);
+    }
+
+    public void log(LogRecord record) {
+        logger.log(record);
+    }
+
+    public Filter getFilter() {
+        return logger.getFilter();
+    }
+
+    public void setFilter(Filter newFilter) throws SecurityException {
+        logger.setFilter(newFilter);
+    }
+
+    public String getResourceBundleName() {
+        return logger.getResourceBundleName();
+    }
+
+    public ResourceBundle getResourceBundle() {
+        return logger.getResourceBundle();
+    }
+
 }


### PR DESCRIPTION
Fixes an issue with custom logging levels not logging properly. All future debug messages shouldn't be removed so they can be viewed with -d true. Keeping them will make it easier to debug if someone has an issue, they just run the program with -d true and the debug messages are already there.