### PR TITLE
Fixes a plugin.yml issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>optic_fusion1</groupId>
     <artifactId>MCAntiMalware</artifactId>
-    <version>3.37</version>
+    <version>3.38</version>
     <packaging>jar</packaging>
     <build>
         <plugins>

--- a/src/main/java/optic_fusion1/mcantimalware/check/CheckManager.java
+++ b/src/main/java/optic_fusion1/mcantimalware/check/CheckManager.java
@@ -92,7 +92,7 @@ public class CheckManager {
             jarEntry = null;
             String author = "";
             String name = "";
-            if (config.isSet("author")) {
+            if (config.isSet("author") && !config.isList("author")) {
                 author = config.getString("author").replaceAll(" ", "-");
                 if (main.shouldLogDebugMessages()) {
                     logger.debug("Author: " + author);
@@ -115,6 +115,8 @@ public class CheckManager {
                     if (main.shouldLogDebugMessages()) {
                         logger.debug(author + "." + name + " is not set");
                     }
+                    inputStream.close();
+                    jarFile.close();
                     return false;
                 }
                 List<String> checksums = checksumDatabase.getStringList(author + "." + name);


### PR DESCRIPTION
Skips any author option that is an array and just checks for name instead of authors.name.
By checking for the author list it would search for [example, example2].pluginname which would always return false