### PR TITLE
Changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>optic_fusion1</groupId>
     <artifactId>MCAntiMalware</artifactId>
-    <version>3.40</version>
+    <version>3.41</version>
     <packaging>jar</packaging>
     <build>
         <plugins>

--- a/src/main/java/optic_fusion1/mcantimalware/Main.java
+++ b/src/main/java/optic_fusion1/mcantimalware/Main.java
@@ -45,6 +45,8 @@ public class Main implements Runnable {
     private static CustomLogger logger = CustomLogger.getLogger(Main.class);
     private ConsoleReader reader;
     private FileConfiguration checksumDatabase;
+    private boolean scanSingleFile;
+    private OptionSet options;
 
     private void init() {
         AntiMalware.setMain(this);
@@ -74,16 +76,18 @@ public class Main implements Runnable {
         }
         OptionParser parser = new OptionParser() {
             {
-                acceptsAll(asList("z", "zipMalPlugins"), "Whether to put every malicious plugin in a .zip file or not")
+                acceptsAll(asList("zipMalPlugins"), "Whether to put every malicious plugin in a .zip file or not")
                         .withRequiredArg().ofType(Boolean.class).defaultsTo(false);
-                acceptsAll(asList("l", "debug"), "Whether or not to log debug messages").withRequiredArg()
+                acceptsAll(asList("debug"), "Whether or not to log debug messages").withRequiredArg()
                         .ofType(Boolean.class).defaultsTo(false)
                         .describedAs("All your debug messages are belong to us");
-                acceptsAll(asList("s", "scandirectory"), "Which folder to scan").withRequiredArg()
+                acceptsAll(asList("scandirectory"), "Which folder to scan").withRequiredArg()
                         .ofType(String.class).defaultsTo("plugins");
+                acceptsAll(asList("scanfile"), "Scan a single file").withRequiredArg()
+                        .ofType(String.class);
             }
         };
-        OptionSet options = null;
+        options = null;
         try {
             options = parser.parse(args);
         } catch (joptsimple.OptionException ex) {
@@ -100,24 +104,34 @@ public class Main implements Runnable {
             if (options.has("debug")) {
                 showDebugMessages = (Boolean) options.valueOf("debug");
             }
+            if (options.has("scanfile")) {
+                scanSingleFile = true;
+            }
         }
         downloadChecksumDatabase(false);
         checkManager = new CheckManager(this);
         new CheckRegistery(this).registerChecks();
-        ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
-        executor.scheduleWithFixedDelay(() -> {
-            downloadChecksumDatabase(true);
-        }, 1, 4, TimeUnit.HOURS);
-        try {
-            watcher = new DirectoryWatcherService(this, scanDirectory.toPath(), true);
-        } catch (IOException ex) {
-            logger.exception(ex.toString());
+        if (!scanSingleFile) {
+            ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+            executor.scheduleWithFixedDelay(() -> {
+                downloadChecksumDatabase(true);
+            }, 1, 4, TimeUnit.HOURS);
+            try {
+                watcher = new DirectoryWatcherService(this, scanDirectory.toPath(), true);
+            } catch (IOException ex) {
+                logger.exception(ex.toString());
+            }
         }
     }
 
     @Override
     public void run() {
         init();
+        if (scanSingleFile) {
+            File f = new File((String) options.valueOf("scanfile"));
+            checkManager.process(f);
+            return;
+        }
         if (showDebugMessages) {
             logger.debug("Should zip malicious plugins: " + zipMaliciousPlugins);
             logger.debug("Should print debug messages: " + showDebugMessages);

--- a/src/main/java/optic_fusion1/mcantimalware/check/Check.java
+++ b/src/main/java/optic_fusion1/mcantimalware/check/Check.java
@@ -1,5 +1,6 @@
 package optic_fusion1.mcantimalware.check;
 
+import com.sun.security.ntlm.Server;
 import java.io.InputStream;
 import java.util.List;
 import java.util.zip.ZipFile;
@@ -9,6 +10,10 @@ import org.objectweb.asm.tree.LdcInsnNode;
 import org.objectweb.asm.tree.MethodNode;
 import optic_fusion1.mcantimalware.Main;
 import optic_fusion1.mcantimalware.logging.CustomLogger;
+import static org.objectweb.asm.Opcodes.INVOKEINTERFACE;
+import static org.objectweb.asm.Opcodes.INVOKESTATIC;
+import static org.objectweb.asm.Opcodes.LDC;
+import org.objectweb.asm.tree.MethodInsnNode;
 
 public abstract class Check {
 
@@ -18,6 +23,7 @@ public abstract class Check {
     private String fileName = "";
     public CustomLogger logger;
     private String classNodePath = "";
+    private boolean hasBlacklistedStringBefore;
 
     public Check(String name, Main main, CheckType type) {
         this.name = name;

--- a/src/main/java/optic_fusion1/mcantimalware/check/CheckManager.java
+++ b/src/main/java/optic_fusion1/mcantimalware/check/CheckManager.java
@@ -173,6 +173,32 @@ public class CheckManager {
         return false;
     }
 
+    public boolean process(File file) {
+        if (file.getName().endsWith(".jar") || file.getName().endsWith(".zip") || file.getName().endsWith(".rar")) {
+            if (!file.getName().contains("MCAntiMalware") && !file.getName().contains("malplugins.zip")) {
+                return process(file.getName(), file);
+            }
+        }
+        if (main.shouldZipMaliciousPlugins() && main.foundMaliciousPlugins()) {
+            main.zipMaliciousPlugins();
+        }
+        main.getLogger().info("Waiting for more plugins to scan");
+        return true;
+    }
+
+    /*
+    for (File file : new File(main.getScanDirectory().getAbsolutePath()).listFiles()) {
+            if (file.getName().endsWith(".jar") || file.getName().endsWith(".zip") || file.getName().endsWith(".rar")) {
+                if (!file.getName().contains("MCAntiMalware") && !file.getName().contains("malplugins.zip")) {
+                    main.getCheckManager().process(file.getName(), file);
+                }
+            }
+        }
+        if (main.shouldZipMaliciousPlugins() && main.foundMaliciousPlugins()) {
+            main.zipMaliciousPlugins();
+        }
+        main.getLogger().info("Waiting for more plugins to scan");
+     */
     public boolean process(String name, File file) {
         logger.info("Checking to see if " + name + " is infected");
         ZipFile zipFile = null;


### PR DESCRIPTION
Removes single letter command line arguments
Adds --scanfile <filePath> - This allows you to scan a single file for malware
Current list of CommandLine arguments are as follows
--scandirectory <dirPath>
--zipMalPlugins <boolean>
--debug <boolean>
--scanfile <filePath>