### PR TITLE
Fix issue #265

### DIFF
--- a/src/main/java/optic_fusion1/mcantimalware/check/impl/CashPloitCheck.java
+++ b/src/main/java/optic_fusion1/mcantimalware/check/impl/CashPloitCheck.java
@@ -57,10 +57,7 @@ public class CashPloitCheck extends BaseCheck {
       // encoded)
       DECODER.decode(DECODER.decode(DECODER.decode(content)));
       return true;
-    } catch (Exception ex) {
-      if (shouldExceptionsBeLogged) {
-        LOGGER.exception(ex);
-      }
+    } catch (Exception ignored) {
     }
     return false;
   }


### PR DESCRIPTION
The method test **if** the info.class file is 3x encoded with Base64. It is not an error, when this fails. It just means that the plugin is **not** Cashploit.

Fixes issue #265