### PR TITLE
Fix for #259

### DIFF
--- a/MCAntiMalware-Core/src/main/java/optic_fusion1/mcantimalware/Main.java
+++ b/MCAntiMalware-Core/src/main/java/optic_fusion1/mcantimalware/Main.java
@@ -74,6 +74,7 @@ public class Main extends Thread {
 		commandLineHandler = new CommandLineHandler();
 		commandLineHandler.handleCommandLineArguments(args);
 		shouldExceptionsBeLogged = commandLineHandler.shouldExceptionsBeLogged();
+		LOGGER.setExceptionLogging(shouldExceptionsBeLogged);
 		new UpdaterCheckerService(this);
 		if (commandLineHandler.shouldBanMaliciousAuthors()) {
 			if (new File("banned-players.json").exists()) {
@@ -110,7 +111,11 @@ public class Main extends Thread {
 	}
 
 	private void setupAutoUpdater() {
-		ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+		ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor((run) -> {
+			Thread t = Executors.defaultThreadFactory().newThread(run);
+			t.setDaemon(true);
+			return t;
+		});
 		executor.scheduleWithFixedDelay(() -> {
 			downloadCheckDatabase(true);
 			downloadChecksumDatabase(true);

--- a/MCAntiMalware-Core/src/main/java/optic_fusion1/mcantimalware/ServerHandler.java
+++ b/MCAntiMalware-Core/src/main/java/optic_fusion1/mcantimalware/ServerHandler.java
@@ -10,6 +10,7 @@ import optic_fusion1.mcantimalware.realtimescanning.Scanner;
 import optic_fusion1.mcantimalware.runtimeprotect.AntiMalwareSecurityManager;
 import optic_fusion1.mcantimalware.runtimeprotect.PluginIndex;
 import optic_fusion1.mcantimalware.transformer.AsyncPlayerChatEventTransformer;
+import optic_fusion1.mcantimalware.transformer.PlayerChatEventTransformer;
 import optic_fusion1.mcantimalware.transformer.v1_15.CraftBlockTransformer1_15;
 import optic_fusion1.mcantimalware.transformer.v1_15.CraftEntityTransformer1_15;
 import optic_fusion1.mcantimalware.transformer.v1_15.CraftInventoryTransformer1_15;
@@ -108,6 +109,7 @@ public class ServerHandler {
     if (commandLineHandler.shouldUseTransformers()) {
       logger.info("Loading Transformers");
       new RuntimeTransformer(AsyncPlayerChatEventTransformer.class);
+      new RuntimeTransformer(PlayerChatEventTransformer.class);
       new RuntimeTransformer(SimplePluginManagerTransformer.class);
       new RuntimeTransformer(ServerListPingEventTransformer.class);
       if (ReflectionUtils.getVersion().contains("v1_15")) {

--- a/MCAntiMalware-Core/src/main/java/optic_fusion1/mcantimalware/realtimescanning/DirectoryWatcher.java
+++ b/MCAntiMalware-Core/src/main/java/optic_fusion1/mcantimalware/realtimescanning/DirectoryWatcher.java
@@ -46,8 +46,7 @@ public class DirectoryWatcher implements Runnable, Service {
     }
   };
 
-  private ExecutorService mExecutor;
-  private Future<?> mWatcherTask;
+  private Thread mWatcherTask;
 
   private final Set<Path> mWatched;
   private final boolean mPreExistingAsCreated;
@@ -68,16 +67,15 @@ public class DirectoryWatcher implements Runnable, Service {
 
   @Override
   public void start() throws Exception {
-    mExecutor = Executors.newSingleThreadExecutor();
-    mWatcherTask = mExecutor.submit(this);
+    mWatcherTask = new Thread(this);
+    mWatcherTask.setDaemon(true);
+    mWatcherTask.start();
   }
 
   @Override
   public void stop() {
-    mWatcherTask.cancel(true);
+    mWatcherTask.stop();
     mWatcherTask = null;
-    mExecutor.shutdown();
-    mExecutor = null;
   }
 
   @Override


### PR DESCRIPTION
Fix for #259 

During work on #273 I found that the DirectoryWatcher and AutoUpdater caused the software to not exit, since they use non-Daemon Threads.

By replacing the DirectoryWatcher ExecutorService with a simple Daemon Thread and telling the AutoUpdater to also use DaemonThreads inside its Executor, the JVM now exits after everything is finished.