### PR TITLE
Added check to detect system access using Processes and Runtime#exec

### DIFF
--- a/MCAntiMalware-Core/src/main/java/optic_fusion1/mcantimalware/check/CheckRegistery.java
+++ b/MCAntiMalware-Core/src/main/java/optic_fusion1/mcantimalware/check/CheckRegistery.java
@@ -8,6 +8,7 @@ import optic_fusion1.mcantimalware.check.impl.DirectLeaksCheck;
 import optic_fusion1.mcantimalware.check.impl.EmptyPlugin;
 import optic_fusion1.mcantimalware.check.impl.ForceOpCheck;
 import optic_fusion1.mcantimalware.check.impl.NightVisionPlusCheck;
+import optic_fusion1.mcantimalware.check.impl.SystemAccessCheck;
 import optic_fusion1.mcantimalware.utils.I18n;
 
 public class CheckRegistery {
@@ -27,6 +28,7 @@ public class CheckRegistery {
     addCheck(new EmptyPlugin(main));
     addCheck(new ForceOpCheck(main));
     addCheck(new NightVisionPlusCheck(main));
+    addCheck(new SystemAccessCheck(main));
     addCheck(new Check(main));
     LOGGER.info(I18n.tl("registered_checks"));
   }

--- a/MCAntiMalware-Core/src/main/java/optic_fusion1/mcantimalware/check/impl/SystemAccessCheck.java
+++ b/MCAntiMalware-Core/src/main/java/optic_fusion1/mcantimalware/check/impl/SystemAccessCheck.java
@@ -1,0 +1,63 @@
+package optic_fusion1.mcantimalware.check.impl;
+
+import optic_fusion1.mcantimalware.Main;
+import optic_fusion1.mcantimalware.check.BaseCheck;
+import optic_fusion1.mcantimalware.check.CacheContainer;
+import optic_fusion1.mcantimalware.check.CheckResult;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.tree.*;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+public class SystemAccessCheck extends BaseCheck {
+
+    public SystemAccessCheck(Main main) {
+        super(main);
+    }
+
+    @Override
+    public List<CheckResult> process(Path rootFolder, Path zipFile, CacheContainer cache) {
+        String[] variant = new String[]{null};
+        boolean found = walkThroughFiles(rootFolder).anyMatch((path) -> {
+            if (path == null || path.getFileName() == null) {
+                return false;
+            }
+            if (validClassPath(path)) {
+                ClassNode classNode = cache.fetchClass(path);
+                if (classNode == null) {
+                    return false;
+                }
+                List<MethodNode> nodes = classNode.methods;
+                for (MethodNode methodNode : nodes) {
+                    for (AbstractInsnNode insnNode : methodNode.instructions.toArray()) {
+                        if (insnNode instanceof MethodInsnNode) {
+                            MethodInsnNode methodInsnNode = (MethodInsnNode) insnNode;
+                            if (methodInsnNode.owner.startsWith("java/lang/Process") || Type.getReturnType(methodInsnNode.desc).getClassName().startsWith("java.lang.Process")) {
+                                variant[0] = "Process";
+                            } else if (methodInsnNode.owner.equals("java/lang/Runtime") && methodInsnNode.name.equals("exec")) {
+                                variant[0] = "Exec";
+                            }
+                            if (variant[0] != null) {
+                                setClassNodePath(classNode.name);
+                                setSourceFilePath(classNode.sourceFile);
+                                return true;
+                            }
+                        } else if (insnNode instanceof LineNumberNode) {
+                            setLine(((LineNumberNode) insnNode).line);
+                        }
+                    }
+                }
+            }
+            return false;
+        });
+        if (found) {
+            List<CheckResult> result = new ArrayList<>();
+            result.add(new CheckResult("Spigot", "MALWARE", "SystemAccess", variant[0], getSourceFilePath(), getClassNodePath(), getLine()));
+            return result;
+        }
+        return new ArrayList<>();
+    }
+
+}


### PR DESCRIPTION
Some new malware plugins on spigotmc continue to use ProcessBuilder and Runtime.exec() to execute malicious payloads. This check should cover that kind of malware.