### PR TITLE
Build Workflow v2

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -29,7 +29,7 @@ jobs:
       uses: softprops/action-gh-release@v1
       with:
         name: Release ${{ steps.get_version.outputs.version }}
-        files: target/*.jar
+        files: MCAntiMalware-Core/target/*.jar
         prerelease: ${{ startsWith(steps.get_version.outputs.version, 'v0.') || startsWith(steps.get_version.outputs.version, '0.') }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -2,16 +2,9 @@
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 
 on:
-  workflow_dispatch:
-    inputs:
-      version:
-        description: "Release Version"
-        required: true
-      description: 
-        description: "Release Description"
-        required: true
-        default: ''
-  
+  push:
+    tags:
+      - '**'
 
 name: Java CI with Maven
 
@@ -25,28 +18,18 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 1.8
+    - name: Get latest release version number
+      id: get_version
+      uses: battila7/get-version-action@v2
     - name: Build with Maven
       run: | 
        cd MCAntiMalware-Core
        mvn -B package --file pom.xml
-    - name: Create Release
-      id: create_release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+    - name: Release
+      uses: softprops/action-gh-release@v1
       with:
-        tag_name: ${{ github.event.inputs.version }}
-        release_name: Release ${{ github.event.inputs.version }}
-        body: ${{ github.event.inputs.description }}
-        draft: false
-        prerelease: false
-    - name: Upload Release Asset
-      id: upload-release-asset 
-      uses: actions/upload-release-asset@v1
+        name: Release ${{ steps.get_version.outputs.version }}
+        files: target/*.jar
+        prerelease: ${{ startsWith(steps.get_version.outputs.version, 'v0.') || startsWith(steps.get_version.outputs.version, '0.') }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
-        asset_path: ./MCAntiMalware-Core/target/MCAntiMalware.jar
-        asset_name: MCAntiMalware.jar
-        asset_content_type: application/zip


### PR DESCRIPTION
The Build Action is now activated via a tag push, so a new tag needs to be created for it to trigger.