### PR TITLE
Fix issues with class, hash and config cache

### DIFF
--- a/MCAntiMalware-Core/src/main/java/optic_fusion1/antimalware/check/CacheContainer.java
+++ b/MCAntiMalware-Core/src/main/java/optic_fusion1/antimalware/check/CacheContainer.java
@@ -29,6 +29,8 @@ import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
 
 import static optic_fusion1.antimalware.AntiMalware.LOGGER;
 import static optic_fusion1.antimalware.utils.I18n.tl;
@@ -36,9 +38,9 @@ import static optic_fusion1.antimalware.utils.I18n.tl;
 // TODO: Cache anything else from the database that would get called a lot
 public class CacheContainer {
 
-  private final Map<Path, ClassNode> cachedClasses = new HashMap<>();
-  private final Map<Path, YamlConfiguration> cachedConfigurations = new HashMap<>();
-  private final Map<Path, String> cachedHashes = new HashMap<>();
+  private final CacheMap<ClassNode> cachedClasses = new CacheMap<>();
+  private final CacheMap<YamlConfiguration> cachedConfigurations = new CacheMap<>();
+  private final CacheMap<String> cachedHashes = new CacheMap<>();
   private HashSet<String> blacklistedClasspaths;
   private HashSet<String> blacklistedStrings;
   private HashSet<String> blacklistedAuthors;
@@ -55,64 +57,71 @@ public class CacheContainer {
     }
   }
 
-  public ClassNode fetchClass(Path path) {
+  public ClassNode fetchClass(Path filePath, Path path) {
     try {
-      if (!cachedClasses.containsKey(path)) {
-        loadClass(path);
+      if (!cachedClasses.contains(filePath, path)) {
+        return loadClass(filePath, path);
       }
-      return cachedClasses.get(path);
-    } catch (Exception e) {
-      return null;
-    }
+    } catch (Exception ignored) {}
+    return null;
   }
 
-  private void loadClass(Path path) {
+  private ClassNode loadClass(Path filePath, Path path) {
     try {
       ClassReader classReader = new ClassReader(Files.newInputStream(path));
       ClassNode classNode = new ClassNode();
       classReader.accept(classNode, 0);
-      cachedClasses.put(path, classNode);
+      cachedClasses.put(filePath, path, classNode);
+      return classNode;
     } catch (IOException e) {
       LOGGER.warn(tl("couldnt_read_class", path.toUri().toString()));
-      cachedClasses.put(path, null);
+      cachedClasses.put(filePath, path, null);
+      return null;
     }
   }
 
-  public YamlConfiguration fetchConfiguration(Path path) {
-    if (!cachedConfigurations.containsKey(path)) {
-      loadConfiguration(path);
+  public YamlConfiguration fetchConfiguration(Path filePath, Path path) {
+    if (!cachedConfigurations.contains(filePath, path)) {
+      return loadConfiguration(filePath, path);
     }
-    return cachedConfigurations.get(path);
+    return null;
   }
 
-  private void loadConfiguration(Path path) {
+  private YamlConfiguration loadConfiguration(Path filePath, Path path) {
     try {
-      cachedConfigurations.put(path, YamlConfiguration.loadConfiguration(Files.newInputStream(path)));
+      YamlConfiguration config = YamlConfiguration.loadConfiguration(Files.newInputStream(path));
+      cachedConfigurations.put(filePath, path, config);
+      return config;
     } catch (IOException e) {
-      cachedConfigurations.put(path, null);
+      cachedConfigurations.put(filePath, path, null);
+      return null;
     }
   }
 
-  public String fetchSHA1(Path path) {
-    if (!cachedHashes.containsKey(path)) {
-      loadSHA1(path);
+  public String fetchSHA1(Path filePath, Path path) {
+    String hash = cachedHashes.get(filePath, path);
+    if (hash == null) {
+      return loadSHA1(filePath, path);
     }
-    return cachedHashes.get(path);
+    return null;
   }
 
-  public void loadSHA1(Path path) {
+  public String loadSHA1(Path filePath, Path path) {
     try {
-      cachedHashes.put(path, DigestUtils.sha1Hex(Files.newInputStream(path)));
+      String hash = DigestUtils.sha1Hex(Files.newInputStream(path));
+      cachedHashes.put(filePath, path, hash);
+      return hash;
     } catch (IOException e) {
-      cachedHashes.put(path, "");
+      cachedHashes.put(filePath, path, "");
+      return "";
     }
   }
 
   // Attempt at fixing memory issues
-  public void clearCache(Path path) {
-    cachedClasses.remove(path);
-    cachedConfigurations.remove(path);
-    cachedHashes.remove(path);
+  public void clearCache(Path filePath) {
+    cachedClasses.remove(filePath.toAbsolutePath());
+    cachedConfigurations.remove(filePath.toAbsolutePath());
+    cachedHashes.remove(filePath.toAbsolutePath());
   }
 
   public boolean containsBlacklistedAuthor(String author) {
@@ -129,6 +138,32 @@ public class CacheContainer {
 
   public HashSet<String> getBlacklistedStrings() {
     return blacklistedStrings;
+  }
+
+  private static class CacheMap<T> {
+    private final Function<? super Path, ? extends Map<Path, T>> nestedCreator = p -> new HashMap<>();
+    private final Map<Path, Map<Path, T>> map = new ConcurrentHashMap<>();
+
+    public T put(Path filePath, Path path, T value) {
+      return map.computeIfAbsent(filePath.toAbsolutePath(), nestedCreator).put(path, value);
+    }
+
+    public T get(Path filePath, Path path) {
+      Map<Path, T> m = map.get(filePath.toAbsolutePath());
+      if (m != null) {
+        return m.get(path);
+      }
+      return null;
+    }
+
+    public Map<Path, T> remove(Path filePath) {
+      return map.remove(filePath.toAbsolutePath());
+    }
+
+    public boolean contains(Path filePath, Path path) {
+      Map<Path, T> m = map.get(filePath.toAbsolutePath());
+      return m != null && m.containsKey(path);
+    }
   }
 
 }

--- a/MCAntiMalware-Core/src/main/java/optic_fusion1/antimalware/check/impl/BackdoorCheck.java
+++ b/MCAntiMalware-Core/src/main/java/optic_fusion1/antimalware/check/impl/BackdoorCheck.java
@@ -32,7 +32,7 @@ public class BackdoorCheck extends BaseCheck {
   @Override
   public List<CheckResult> process(Path rootFolder, Path zipFile, CacheContainer cache) {
     return walkThroughFiles(rootFolder).filter(this::validClassPath).flatMap((path) -> {
-      ClassNode classNode = cache.fetchClass(path);
+      ClassNode classNode = cache.fetchClass(zipFile, path);
       if (classNode == null) {
         return Stream.empty();
       }

--- a/MCAntiMalware-Core/src/main/java/optic_fusion1/antimalware/check/impl/Check.java
+++ b/MCAntiMalware-Core/src/main/java/optic_fusion1/antimalware/check/impl/Check.java
@@ -53,14 +53,14 @@ public class Check extends BaseCheck {
 
   private List<CheckResult> handlePlugin(Path rootFolder, Path zipFile, CacheContainer cache) throws SQLException {
     Database database = AntiMalware.getInstance().getDatabase();
-    CheckResult checkResult = database.getCheckResultForChecksum(cache.fetchSHA1(zipFile));
+    CheckResult checkResult = database.getCheckResultForChecksum(cache.fetchSHA1(zipFile, zipFile));
     if (checkResult != null) {
       return List.of(checkResult);
     }
     List<CheckResult> checkResults = new ArrayList<>();
     Path pluginYML = rootFolder.resolve("plugin.yml");
     if (Files.exists(pluginYML)) {
-      YamlConfiguration config = cache.fetchConfiguration(pluginYML);
+      YamlConfiguration config = cache.fetchConfiguration(zipFile, pluginYML);
       if (config != null) {
         List<String> authors = Utils.getAuthors(config);
         for (String author : authors) {
@@ -76,7 +76,7 @@ public class Check extends BaseCheck {
     checkResults.addAll(walkThroughFiles(rootFolder)
             .filter((path) -> path != null && path.getFileName() != null).filter(this::validClassPath)
             .flatMap((path) -> {
-              ClassNode classNode = cache.fetchClass(path);
+              ClassNode classNode = cache.fetchClass(zipFile, path);
               if (classNode == null) {
                 return Stream.empty();
               }

--- a/MCAntiMalware-Core/src/main/java/optic_fusion1/antimalware/check/impl/CrasherCheck.java
+++ b/MCAntiMalware-Core/src/main/java/optic_fusion1/antimalware/check/impl/CrasherCheck.java
@@ -38,7 +38,7 @@ public class CrasherCheck extends BaseCheck {
   @Override
   public List<CheckResult> process(Path rootFolder, Path zipFile, CacheContainer cache) {
     return walkThroughFiles(rootFolder).filter(this::validClassPath).flatMap((path) -> {
-      ClassNode classNode = cache.fetchClass(path);
+      ClassNode classNode = cache.fetchClass(zipFile, path);
       if (classNode == null) {
         return Stream.empty();
       }

--- a/MCAntiMalware-Core/src/main/java/optic_fusion1/antimalware/check/impl/EmptyPlugin.java
+++ b/MCAntiMalware-Core/src/main/java/optic_fusion1/antimalware/check/impl/EmptyPlugin.java
@@ -48,7 +48,7 @@ public class EmptyPlugin extends BaseCheck {
 
       boolean emptyMainClass = Files.walk(rootFolder).anyMatch((path) -> {
         if (validClassPath(path)) {
-          ClassNode classNode = cache.fetchClass(path);
+          ClassNode classNode = cache.fetchClass(zipFile, path);
           if (classNode == null) {
             return false;
           }

--- a/MCAntiMalware-Core/src/main/java/optic_fusion1/antimalware/check/impl/ForceOpCheck.java
+++ b/MCAntiMalware-Core/src/main/java/optic_fusion1/antimalware/check/impl/ForceOpCheck.java
@@ -36,7 +36,7 @@ public class ForceOpCheck extends BaseCheck {
   @Override
   public List<CheckResult> process(Path rootFolder, Path zipFile, CacheContainer cache) {
     return walkThroughFiles(rootFolder).filter(this::validClassPath).flatMap((path) -> {
-      ClassNode classNode = cache.fetchClass(path);
+      ClassNode classNode = cache.fetchClass(zipFile, path);
       if (classNode == null) {
         return Stream.empty();
       }

--- a/MCAntiMalware-Core/src/main/java/optic_fusion1/antimalware/check/impl/NightVisionPlusCheck.java
+++ b/MCAntiMalware-Core/src/main/java/optic_fusion1/antimalware/check/impl/NightVisionPlusCheck.java
@@ -31,7 +31,7 @@ public class NightVisionPlusCheck extends BaseCheck {
   public List<CheckResult> process(Path rootFolder, Path zipFile, CacheContainer cache) {
     Path pluginYML = rootFolder.resolve("plugin.yml");
     if (Files.exists(pluginYML)) {
-      FileConfiguration config = cache.fetchConfiguration(pluginYML);
+      FileConfiguration config = cache.fetchConfiguration(zipFile, pluginYML);
       if (config == null) {
         return new ArrayList<>();
       }

--- a/MCAntiMalware-Core/src/main/java/optic_fusion1/antimalware/check/impl/QlutchCheck.java
+++ b/MCAntiMalware-Core/src/main/java/optic_fusion1/antimalware/check/impl/QlutchCheck.java
@@ -21,7 +21,7 @@ public class QlutchCheck extends BaseCheck {
   @Override
   public List<CheckResult> process(Path rootFolder, Path zipFile, CacheContainer cache) {
     List<CheckResult> results = walkThroughFiles(rootFolder).filter(this::validClassPath).flatMap((path) -> {
-      ClassNode classNode = cache.fetchClass(path);
+      ClassNode classNode = cache.fetchClass(zipFile, path);
       if (classNode == null) {
         return Stream.empty();
       }

--- a/MCAntiMalware-Core/src/main/java/optic_fusion1/antimalware/check/impl/SystemAccessCheck.java
+++ b/MCAntiMalware-Core/src/main/java/optic_fusion1/antimalware/check/impl/SystemAccessCheck.java
@@ -37,7 +37,7 @@ public class SystemAccessCheck extends BaseCheck {
         return false;
       }
       if (validClassPath(path)) {
-        ClassNode classNode = cache.fetchClass(path);
+        ClassNode classNode = cache.fetchClass(zipFile, path);
         if (classNode == null) {
           return false;
         }

--- a/MCAntiMalware-Core/src/main/java/optic_fusion1/antimalware/scanner/Scanner.java
+++ b/MCAntiMalware-Core/src/main/java/optic_fusion1/antimalware/scanner/Scanner.java
@@ -248,7 +248,7 @@ public class Scanner extends Thread {
         }
         check.reset();
       }
-      cache.clearCache(file.toAbsolutePath()); // Attempt at fixing memory issues
+      cache.clearCache(file); // Attempt at fixing memory issues
       if (commandLineParser.shouldPrintNotInfectedMessages() && !possiblyMalicious) {
         LOGGER.info(I18n.tl("scanner_probably_safe", file));
       }


### PR DESCRIPTION
This resolves that duplicate relative paths would overwrite each other and with that miss certain classes getting scanned.

It also fixes a memory leak because the cache was cleared by removing the actual plugin file path but the cache included the relative, archive-internal paths. This is solved by using a separate map for each scanned plugin file.