### PR TITLE
Implement ProcessCreationCheck for sub processes

### DIFF
--- a/MCAntiMalware-Core/src/main/java/optic_fusion1/antimalware/check/CheckRegistery.java
+++ b/MCAntiMalware-Core/src/main/java/optic_fusion1/antimalware/check/CheckRegistery.java
@@ -17,22 +17,11 @@
 package optic_fusion1.antimalware.check;
 
 import optic_fusion1.antimalware.AntiMalware;
-import static optic_fusion1.antimalware.AntiMalware.LOGGER;
-import optic_fusion1.antimalware.check.impl.BackdoorCheck;
-import optic_fusion1.antimalware.check.impl.CashPloitCheck;
-import optic_fusion1.antimalware.check.impl.Check;
-import optic_fusion1.antimalware.check.impl.CrasherCheck;
-import optic_fusion1.antimalware.check.impl.DispatchCommandCheck;
-import optic_fusion1.antimalware.check.impl.NightVisionPlusCheck;
-import optic_fusion1.antimalware.check.impl.NonVanillaEnchantCheck;
-import optic_fusion1.antimalware.check.impl.QlutchCheck;
-import optic_fusion1.antimalware.check.impl.SystemAccessCheck;
-import optic_fusion1.antimalware.check.impl.forceop.ForceOpCheckA;
-import optic_fusion1.antimalware.check.impl.forceop.ForceOpCheckB;
-import optic_fusion1.antimalware.check.impl.forceop.ForceOpCheckC;
-import optic_fusion1.antimalware.check.impl.forceop.ForceOpCheckD;
-import optic_fusion1.antimalware.check.impl.forceop.ForceOpCheckF;
+import optic_fusion1.antimalware.check.impl.*;
+import optic_fusion1.antimalware.check.impl.forceop.*;
 import optic_fusion1.antimalware.utils.I18n;
+
+import static optic_fusion1.antimalware.AntiMalware.LOGGER;
 
 public class CheckRegistery {
 
@@ -64,6 +53,7 @@ public class CheckRegistery {
         addCheck(new SystemAccessCheck());
         addCheck(new Check());
         addCheck(new BackdoorCheck());
+        addCheck(new ProcessCreationCheck());
         addCheck(new CrasherCheck());
         addCheck(new QlutchCheck());
         addCheck(new NonVanillaEnchantCheck());

--- a/MCAntiMalware-Core/src/main/java/optic_fusion1/antimalware/check/impl/ProcessCreationCheck.java
+++ b/MCAntiMalware-Core/src/main/java/optic_fusion1/antimalware/check/impl/ProcessCreationCheck.java
@@ -42,7 +42,7 @@ public final class ProcessCreationCheck extends BaseCheck {
                     if (!methodInsnNode.owner.equals("java/lang/ProcessBuilder")) continue;
                     if (!methodInsnNode.name.equals("start")) continue;
                     results.add(new CheckResult(
-                            "Spigot", "MALWARE", "Botnet-Downloader",
+                            "Spigot", "MALWARE/PUP", "Process-Creation",
                             classNode.name + "#" + method.name + ": creating subprocesses"));
                 }
             }

--- a/MCAntiMalware-Core/src/main/java/optic_fusion1/antimalware/check/impl/ProcessCreationCheck.java
+++ b/MCAntiMalware-Core/src/main/java/optic_fusion1/antimalware/check/impl/ProcessCreationCheck.java
@@ -1,0 +1,52 @@
+/*
+* Copyright (C) 2021 Optic_Fusion1
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package optic_fusion1.antimalware.check.impl;
+
+import optic_fusion1.antimalware.check.BaseCheck;
+import optic_fusion1.antimalware.check.CacheContainer;
+import optic_fusion1.antimalware.check.CheckResult;
+import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.MethodInsnNode;
+import org.objectweb.asm.tree.MethodNode;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+public final class ProcessCreationCheck extends BaseCheck {
+
+    @Override
+    public List<CheckResult> process(final ClassNode classNode,
+                                     final Path rootFolder,
+                                     final Path zipFile,
+                                     final CacheContainer cache) {
+        final List<CheckResult> results = new ArrayList<>();
+        for (final MethodNode method : classNode.methods) {
+            for (final AbstractInsnNode instruction : method.instructions) {
+                if (instruction instanceof MethodInsnNode methodInsnNode) {
+                    if (!methodInsnNode.owner.equals("java/lang/ProcessBuilder")) continue;
+                    if (!methodInsnNode.name.equals("start")) continue;
+                    results.add(new CheckResult(
+                            "Spigot", "MALWARE", "Botnet-Downloader",
+                            classNode.name + "#" + method.name + ": creating subprocesses"));
+                }
+            }
+        }
+        return results;
+    }
+}


### PR DESCRIPTION
Recently, some of my friends discovered a new type of malware on SpigotMC.
This type of malware downloads an ELF binary file and runs it using `Process process = processBuilder.start();`

Links to infected resources:
- https://www.spigotmc.org/resources/bedhome.115389/
- https://www.spigotmc.org/resources/anarchyexploitfixes.115385/ (offline)

Both infected resources are currently not picked up, but are detected using this small check I implemented.
I don't think that it causes any issues since no plugin has to create sub processes.
I tried running it on a few plugins (AuthMe, SkinsRestorer, ...), and it only detected the infected plugin.